### PR TITLE
[1.43] UserPageViewTracker: update to latest REL1_43 commit

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -593,7 +593,7 @@ extensions:
     commit: f9d2664fd1af70a2b3a22a55b971c174593d38f1
 - UserPageViewTracker:
     Wikidata ID: Q21679006
-    commit: a3009ef62873535de56e18f62d629ca3494e9d77
+    commit: e92d6c8fc3e491a451494b0d4a194b8ead60ad74
     additional steps:
     - database update
 - Variables:


### PR DESCRIPTION
Specifically, update to include
wikimedia/mediawiki-extensions-UserPageViewTracker@4acca032aeac6729fe77f8edb9834bb1ae4015db which unbreaks the pager query.