### PR TITLE
[1.43] ContributionScores: use latest master

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -127,7 +127,8 @@ extensions:
     commit: 733c519feeafdf296b288500f317512262ffecb7
 - ContributionScores:
     Wikidata ID: Q21676708
-    commit: 6370730e6cec3ccff17d2ea988dd414fa87f1e16
+    branch: master
+    commit: 6f95b63a0bedfcfeb349d87b9943d873232c9bd2
 - CookieWarning:
     Wikidata ID: Q26719043
     commit: f697459d94ac1aa8c9d3e417a9b0e04f92640447


### PR DESCRIPTION
Specifically so that we include
wikimedia/mediawiki-extensions-ContributionScores@6f95b63a0bedfcfeb349d87b9943d873232c9bd2 which fixes the extension for MediaWiki 1.42+ where the `ipblocks` table no longer exists.