### PR TITLE
Update 1.43.yaml - update to latest WhosOnline

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -632,8 +632,7 @@ extensions:
     commit: ad0d721ab588c77678a33db304a77bd684724a1a
 - WhosOnline:
     Wikidata ID: Q21679159
-    branch: master
-    commit: c707c2935f5e9f739f306c828a54476e47c40cc6
+    commit: 29f2c73742071244a0906981417510e5bce9fcd7
     additional steps:
     - database update
 - Widgets:

--- a/1.43.yaml
+++ b/1.43.yaml
@@ -632,7 +632,8 @@ extensions:
     commit: ad0d721ab588c77678a33db304a77bd684724a1a
 - WhosOnline:
     Wikidata ID: Q21679159
-    commit: e072d08f58ea013a40f27dd95ef1eef8bca364c2
+    branch: master
+    commit: c707c2935f5e9f739f306c828a54476e47c40cc6
     additional steps:
     - database update
 - Widgets:


### PR DESCRIPTION
The previous version of WhosOnline did not work with MW 1.41+.