### PR TITLE
[1.43] SubPageList: update to latest release

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -532,7 +532,7 @@ extensions:
 - SubPageList:
     Wikidata ID: Q21678751
     repository: https://github.com/ProfessionalWiki/SubPageList
-    commit: c016dcdb7866f20319731e6497b48fd43756505e # v. 3.0.0
+    commit: ae42bd0f2c3e0c73b82787692c75a13cee929121 # v. 3.0.1
 - SyntaxHighlight:
     Wikidata ID: Q21678766
     bundled: true


### PR DESCRIPTION
Version 3.0.0 is not compatible with MediaWiki 1.43