### PR TITLE
Update WSOAuth to latest master for User-Agent fix

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -650,7 +650,7 @@ extensions:
     commit: 86611359bfc639beb1b567d7df0edf25a0441aa0
 - WSOAuth:
     Wikidata ID: Q117027185
-    commit: 9f25fade2bcd3fae44c3236072f5ea2eb068b75c
+    commit: 602cd253753a726d404747f10cba631509a32904
     additional steps:
     - composer update
     - database update

--- a/1.44.yaml
+++ b/1.44.yaml
@@ -648,7 +648,7 @@ extensions:
     commit: 47745015c696a341e704e9fa3db0b6a4aad6ccb1
 - WSOAuth:
     Wikidata ID: Q117027185
-    commit: df7e745b69ec61f2cc204546b5c8da098c31cc13
+    commit: 602cd253753a726d404747f10cba631509a32904
     additional steps:
     - composer update
     - database update


### PR DESCRIPTION
## Summary
- Update WSOAuth pinned commit in 1.43.yaml and 1.44.yaml to head of master (`602cd253`)
- The previous commits lack a User-Agent header when making OAuth requests to Wikimedia servers, which now enforce a User-Agent policy
- Without this fix, WSOAuth fails with "Failed to decode server response as JSON: Syntax error" because the server returns a plain-text error instead of JSON

Fixes #8