### PR TITLE
Reframe CI: per-extension isolated validation

### DIFF
--- a/.ci/coexistence_groups.yaml
+++ b/.ci/coexistence_groups.yaml
@@ -23,9 +23,6 @@ groups:
       - SemanticExtraSpecialProperties
       - SemanticScribunto
       - SemanticWatchlist
-      - SemanticBreadcrumbLinks
-      - SemanticFormsSelect
-      - SemanticTasks
       - Mermaid
       - Scribunto  # required by SemanticScribunto
 

--- a/.ci/run_isolated_tests.py
+++ b/.ci/run_isolated_tests.py
@@ -132,9 +132,21 @@ def run_db_update(mw_dir: str) -> bool:
         return False
 
 
-def run_phpunit(mw_dir: str, test_dir: str, result_file: str, timeout: int = 300) -> dict:
+def run_phpunit(
+    mw_dir: str,
+    test_dir: str,
+    result_file: str,
+    exclude_files: list[str] | None = None,
+    timeout: int = 300,
+) -> dict:
     """
     Run PHPUnit for an extension's test directory.
+
+    Args:
+        exclude_files: Optional list of test file paths (relative to extension
+                       root) to exclude.  Since PHPUnit 9 has no --exclude-file
+                       flag, we enumerate the test files and omit the excluded
+                       ones, passing the remaining files individually.
 
     Returns a dict with status and details.
     """
@@ -143,8 +155,36 @@ def run_phpunit(mw_dir: str, test_dir: str, result_file: str, timeout: int = 300
         return {"status": "error", "message": "No PHPUnit runner found"}
 
     try:
+        cmd = ["php", phpunit_runner, "--log-junit", result_file]
+
+        if exclude_files:
+            # Resolve excluded paths to absolute paths for comparison.
+            # test_dir is <mw_dir>/extensions/<Name>/tests/phpunit
+            # exclude paths are relative to <mw_dir>/extensions/<Name>/
+            ext_base = os.path.dirname(os.path.dirname(test_dir))
+            excluded_abs = set()
+            for ef in exclude_files:
+                abs_path = os.path.realpath(os.path.join(ext_base, ef))
+                excluded_abs.add(abs_path)
+
+            # Enumerate all test PHP files and filter out excluded ones.
+            test_files = []
+            for root, _dirs, files in os.walk(test_dir):
+                for f in sorted(files):
+                    if f.endswith(".php"):
+                        fpath = os.path.realpath(os.path.join(root, f))
+                        if fpath not in excluded_abs:
+                            test_files.append(fpath)
+
+            if not test_files:
+                return {"status": "no_tests", "message": "All test files excluded"}
+
+            cmd.extend(test_files)
+        else:
+            cmd.append(test_dir)
+
         proc = subprocess.run(
-            ["php", phpunit_runner, "--log-junit", result_file, test_dir],
+            cmd,
             cwd=mw_dir,
             capture_output=True,
             text=True,
@@ -265,9 +305,13 @@ def main():
             continue
 
         # ── Phase 4: Run PHPUnit tests ───────────────────────────────
-        print(f"  Running PHPUnit tests...")
+        exclude_files = entry.get("exclude_tests", [])
+        if exclude_files:
+            print(f"  Running PHPUnit tests (excluding {len(exclude_files)} file(s))...")
+        else:
+            print(f"  Running PHPUnit tests...")
         result_file = os.path.join(results_dir, f"{name}.xml")
-        test_result = run_phpunit(mw_dir, test_dir, result_file)
+        test_result = run_phpunit(mw_dir, test_dir, result_file, exclude_files=exclude_files)
 
         status = test_result["status"]
         results["details"][name] = test_result

--- a/.ci/skip_list.yaml
+++ b/.ci/skip_list.yaml
@@ -108,8 +108,20 @@ upstream_test_compat:
     reason: Integration test suite errors / dependency on SMW test classes
   - name: SemanticScribunto
     reason: Integration test suite errors / dependency on SMW test classes
-  - name: Cargo
-    reason: Fails 1 test inside its own suite under PHP 8.3/MW 1.43
-  - name: PageForms
-    reason: Fails assertions and has errors due to environment differences under MW 1.43
 
+# ── Extensions with partial test exclusions ──────────────────────────────────
+# These extensions pass the vast majority of their test suite. Only a few
+# specific test files fail due to MW 1.43 / PHP 8.3 incompatibilities.
+# The listed test files are excluded; the rest of the suite runs normally
+# and counts as blocking validation.
+
+partial_test_compat:
+  - name: Cargo
+    reason: CargoFeedFormatTest expects old heading HTML; MW 1.43 changed heading markup
+    exclude_tests:
+      - tests/phpunit/integration/formats/CargoFeedFormatTest.php
+  - name: PageForms
+    reason: PFHelperFormActionTest references removed MediaWiki\Skin\SkinTemplate class; PFFormLinkerTest has environment-dependent assertion
+    exclude_tests:
+      - tests/phpunit/integration/includes/PFFormLinkerTest.php
+      - tests/phpunit/integration/includes/PFHelperFormActionTest.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,7 +639,12 @@ jobs:
               print(f"   All {len(installed)} extensions coexist without fatal errors.")
           else:
               print(f"❌ Co-existence group '{group_name}' has load errors!")
-              print(verify.stderr[-500:] if verify.stderr else "Unknown error")
+              if verify.stderr:
+                  print(verify.stderr[-500:])
+              elif verify.stdout:
+                  print(verify.stdout[-500:])
+              else:
+                  print(f"Exit code: {verify.returncode}, no output captured")
               sys.exit(1)
           COEXIST_TEST
 

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -293,21 +293,25 @@ def load_skip_list(ci_dir: str) -> dict:
       {
         "external_services": {"ExtName", ...},
         "upstream_test_compat": {"ExtName", ...},
+        "partial_test_compat": {"ExtName": ["path/to/excluded_test.php", ...], ...},
       }
     """
     skip_path = os.path.join(ci_dir, "skip_list.yaml")
     if not os.path.exists(skip_path):
-        return {"external_services": set(), "upstream_test_compat": set()}
+        return {"external_services": set(), "upstream_test_compat": set(),
+                "partial_test_compat": {}}
 
     with open(skip_path) as f:
         data = yaml.safe_load(f)
 
     if not data:
-        return {"external_services": set(), "upstream_test_compat": set()}
+        return {"external_services": set(), "upstream_test_compat": set(),
+                "partial_test_compat": {}}
 
     result = {
         "external_services": set(),
         "upstream_test_compat": set(),
+        "partial_test_compat": {},
     }
 
     # Handle the new categorized format.
@@ -315,6 +319,8 @@ def load_skip_list(ci_dir: str) -> dict:
         result["external_services"].add(item["name"])
     for item in data.get("upstream_test_compat", []):
         result["upstream_test_compat"].add(item["name"])
+    for item in data.get("partial_test_compat", []):
+        result["partial_test_compat"][item["name"]] = item.get("exclude_tests", [])
 
     # Backward compat: also handle the old flat "skip:" format.
     for item in data.get("skip", []):
@@ -390,6 +396,7 @@ def build_manifest(yaml_path: str, skip_data: dict | None = None) -> dict:
     if skip_data:
         external = skip_data.get("external_services", set())
         upstream = skip_data.get("upstream_test_compat", set())
+        partial = skip_data.get("partial_test_compat", {})
 
         for e in all_entries:
             if e["name"] in external:
@@ -401,6 +408,10 @@ def build_manifest(yaml_path: str, skip_data: dict | None = None) -> dict:
                 e["skip_tests"] = True
                 e["skip_reason"] = "Upstream test compat issue (non-blocking)"
                 e["skip_category"] = "upstream_test_compat"
+            elif e["name"] in partial:
+                e["skip"] = False
+                e["exclude_tests"] = partial[e["name"]]
+                e["skip_category"] = "partial_test_compat"
 
         # Transitive skipping: if a required extension is fully skipped
         # (external_services), skip dependents too.


### PR DESCRIPTION
**Overview**
This PR updates our CI setup to run tests for extensions like `Cargo` and `PageForms` that we were previously skipping entirely due to a few minor incompatibilities with MediaWiki 1.43 / PHP 8.3. Instead of skipping their entire test suites, we can now run all tests while excluding only the specific files that are failing.

I've also cleaned up the coexistence testing configuration to remove some old extensions that don't exist in our current manifest, and improved how we capture logs when coexistence checks fail.

**Key Changes**

* **Partial Test Exclusions for PHPUnit**
  * Added a new `partial_test_compat` section in [.ci/skip_list.yaml](.ci/skip_list.yaml) to declare which files should be bypassed for each extension.
  * Updated `load_skip_list` and `build_manifest` in [scripts/parse_yaml.py](scripts/parse_yaml.py) to parse this list and pass the excluded file paths in the manifest.
  * Updated `run_phpunit` in [.ci/run_isolated_tests.py](.ci/run_isolated_tests.py) to support exclusions. Since PHPUnit 9 doesn't have an `--exclude-file` flag, we dynamically walk the directory, filter out the excluded paths, and pass the remaining test files individually.
    * *Cargo test bypassed:* `CargoFeedFormatTest.php` (fails because MW 1.43 changed heading HTML markup).
    * *PageForms tests bypassed:* `PFFormLinkerTest.php` (environment-dependent assertion) and `PFHelperFormActionTest.php` (references the deprecated/removed `SkinTemplate` class).

* **Coexistence Group Cleanup & Diagnostics**
  * Removed `SemanticBreadcrumbLinks`, `SemanticFormsSelect`, and `SemanticTasks` from the `semantic-ecosystem` group in [.ci/coexistence_groups.yaml](.ci/coexistence_groups.yaml) since they are not present in the `1.43.yaml` manifest.
  * Updated [.github/workflows/ci.yml](.github/workflows/ci.yml) to log `verify.stdout` if `verify.stderr` is empty when a coexistence group fails to load, which helps capture PHP errors and warnings.
