### PR TITLE
Add CreateUserPage extension for MediaWiki 1.43

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -143,6 +143,9 @@ extensions:
 - CreateRedirect:
     Wikidata ID: Q21676753
     commit: 17f4ab36038cdf7d568bd17dcf8ebc2110c9dcb9
+- CreateUserPage:
+    Wikidata ID: Q30248654
+    commit: 2b467c4ad37759294f3584fc5217e000d9df1d90
 - DataTransfer:
     Wikidata ID: Q21677041
     branch: master


### PR DESCRIPTION
Adds the [CreateUserPage](https://www.mediawiki.org/wiki/Extension:Create_User_Page) extension to `1.43.yaml`, pinned to the current `REL1_43` head.

```yaml
- CreateUserPage:
    Wikidata ID: Q30248654
    commit: 2b467c4ad37759294f3584fc5217e000d9df1d90
```

- Wikimedia-hosted extension, so it uses the default Wikimedia git repo and the `REL1_43` branch.
- No `additional steps`: the extension declares no schema updates (no `LoadExtensionSchemaUpdates` hook) and has no composer dependencies. It only requires MediaWiki >= 1.40.

This is the prerequisite for bundling CreateUserPage in Canasta — once merged, Canasta's `contents.yaml` pin will be bumped to pick it up.

Tracking issue: CanastaWiki/Canasta#638