### PR TITLE
Bump TemplateStyles to css-sanitizer ^6 commit for MW 1.43.9 (#17)

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -562,7 +562,7 @@ extensions:
     commit: db217336a3e2c455c5e24303b2e793623b80a055
 - TemplateStyles:
     Wikidata ID: Q25916623
-    commit: 31a4bd259a921e19b4857befa700e7fc0998b6d2
+    commit: daad80e73caa4e9f5b538361a155f933c33d50c2
     additional steps:
     - composer update
 - TemplateStylesExtender:


### PR DESCRIPTION
Fixes #17.

MediaWiki 1.43.9 bumped MW core's `wikimedia/css-sanitizer` requirement to `6.2.1`, but the pinned TemplateStyles commit (`31a4bd2…`) still required css-sanitizer `^5.x`. The constraints conflict, so CanastaBase's unified `composer update` fails resolution and installs **none** of the merged extension dependencies — Canasta 3.5.11 ships a `vendor/` of 222 packages vs 378, missing `ruflin/elastica`, `onoi/*`, and SMW's `data-values/*`. Result: `Class "Elastica\Client" not found` / `Class "SMW\Setup" not found` on any wiki using a bundled Composer extension.

Moves the pin to current `REL1_43` HEAD (`daad80e73caa4e9f5b538361a155f933c33d50c2`), which requires css-sanitizer `^6.0.0`.

**Verified:** swapping in this TemplateStyles `composer.json` in a `canasta:3.5.11` container makes `composer update` resolve cleanly (`202 installs`), including `ruflin/elastica (7.3.1)` and `data-values/data-values (3.1.1)`.

Downstream: after merge, bump Canasta `contents.yaml`'s RR `inherits` pin and re-cut Canasta (3.5.12). `1.44.yaml`'s TemplateStyles pin should be checked separately.