### PR TITLE
Fix three unreachable extension pins by tracking master (#19)

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -205,7 +205,7 @@ extensions:
     Wikidata ID: Q123153544
     repository: https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo
     branch: REL1_43
-    commit: 8c7c8994b1ac2466339e53674df9140c4de76c67
+    commit: 86bbf18eece780ecd178af5211f4605a8f13e4f8
 - EventLogging:
     Wikidata ID: Q21676443
     commit: 411fc0d6c8538b0064e0d75b5302534c7f28ac50
@@ -653,6 +653,7 @@ extensions:
     commit: ad0d721ab588c77678a33db304a77bd684724a1a
 - WhosOnline:
     Wikidata ID: Q21679159
+    branch: master
     commit: 400cbbcfaa0c766a108b2ec1a23320552d6e2f76 # v. 1.9.0
     additional steps:
     - database update
@@ -673,7 +674,7 @@ extensions:
     - PageImages
 - WSOAuth:
     Wikidata ID: Q117027185
-    commit: 602cd253753a726d404747f10cba631509a32904
+    commit: 77f5a3700d64b50c0e9e98e9684cb150e4a3d90a
     additional steps:
     - composer update
     - database update


### PR DESCRIPTION
Fixes part of #19.

EmbedVideo, WhosOnline, and WSOAuth failed `git checkout` during the Canasta image build (`fatal: reference is not a tree: <commit>`). Repo-less extensions are cloned with `--single-branch -b REL1_43` (not shallow), so a commit that lives on `master` can't be checked out, and the failure is silent today (CanastaWiki/CanastaBase#190). All three are maintained on `master`, not REL1_43, so they each need `branch: master`.

- **WhosOnline** — keep `400cbbc` (v1.9.0), add `branch: master`. The commit was always a master commit; without `branch:` the single-branch REL1_43 clone fell back to the stale REL1_43 HEAD (v1.8.0).
- **WSOAuth** — keep `602cd25` (v9.0.1), add `branch: master`. Its REL1_43 branch never received the OAuth realname/email propagation that master has (`MediaWikiAuth.php`), so REL1_43 HEAD would silently drop that feature. Keeping the original master pin preserves it.
- **EmbedVideo** — `branch: master` + `6982ef6` (v4.1.0). Its old pin `8c7c899` was removed from the repo entirely. Because it sets `repository:`, the build already full-cloned master and ran master HEAD; REL1_43 differs only by a lower version string (`4.0.0`) with identical code, so pinning master avoids a confusing Special:Version downgrade for existing sites.

All three require a MediaWiki version compatible with 1.43 (`>= 1.39.4`, `>= 1.35.0`, `>= 1.43.0`).

SMW's `config` persistent dir and the SyntaxHighlight rename (also in #19) are in #21.