### PR TITLE
Fix SMW persistent-directory and SyntaxHighlight name (#19)

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -496,8 +496,6 @@ extensions:
     Wikidata ID: Q20728
     repository: https://github.com/SemanticMediaWiki/SemanticMediaWiki
     commit: 16171910b16165089d19fc6f66c414e6f62aa1eb # v. 6.0.0
-    persistent directories:
-    - config
     additional steps:
     - composer update
     - database update
@@ -551,7 +549,7 @@ extensions:
     Wikidata ID: Q21678751
     repository: https://github.com/ProfessionalWiki/SubPageList
     commit: ae42bd0f2c3e0c73b82787692c75a13cee929121 # v. 3.0.1
-- SyntaxHighlight:
+- SyntaxHighlight_GeSHi:
     Wikidata ID: Q21678766
     bundled: true
 - TemplateData:


### PR DESCRIPTION
Fixes the remaining two items in #19 (the stale extension pins are in #20).

## SemanticMediaWiki — remove `persistent directories: [config]`
```
mv: cannot stat '.../SemanticMediaWiki/config': No such file or directory
```
The `config` persistent directory was added in CanastaWiki/Canasta#423 when SMW was pinned to **v4.1.3**, which shipped a top-level `config/` directory. The current pin is **v6.0.0**, which no longer has one, so the `mv` fails on every build. SMW's runtime state (`.smw.json`) is persisted separately under `config/persistent/` (CanastaBase), so nothing is lost by dropping this entry.

## SyntaxHighlight — rename to `SyntaxHighlight_GeSHi`
```
sh: 1: cd: can't cd to '.../canasta-extensions/SyntaxHighlight'
```
Per [Extension:SyntaxHighlight](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight), the canonical extension and directory name is **`SyntaxHighlight_GeSHi`** — the "SyntaxHighlight" rebrand (GeSHi → Pygments) kept the old internal name. The RR entry was named `SyntaxHighlight`, so the gitinfo step `cd`'d into a directory that doesn't exist. Renaming matches the real bundled directory. Runtime loading is unaffected — it's `settings.yaml`-driven and already requires `SyntaxHighlight_GeSHi`.

## Note
`1.44.yaml` has the same two issues (SyntaxHighlight rename applies as-is; the SMW `config` entry should be checked against whatever SMW version 1.44 pins). Can be handled in a follow-up.