### PR TITLE
Track master for EmbedVideo and WSOAuth (#19)

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -204,8 +204,8 @@ extensions:
 - EmbedVideo:
     Wikidata ID: Q123153544
     repository: https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo
-    branch: REL1_43
-    commit: 86bbf18eece780ecd178af5211f4605a8f13e4f8
+    branch: master
+    commit: 6982ef6e10a8327a6ecc97eb036f4eb531a6f830 # v. 4.1.0
 - EventLogging:
     Wikidata ID: Q21676443
     commit: 411fc0d6c8538b0064e0d75b5302534c7f28ac50
@@ -672,7 +672,8 @@ extensions:
     - PageImages
 - WSOAuth:
     Wikidata ID: Q117027185
-    commit: 77f5a3700d64b50c0e9e98e9684cb150e4a3d90a
+    branch: master
+    commit: 602cd253753a726d404747f10cba631509a32904 # v. 9.0.1
     additional steps:
     - composer update
     - database update


### PR DESCRIPTION
Follow-up to #20 (merged), which landed WhosOnline on master but left EmbedVideo and WSOAuth on REL1_43. Both are maintained on master, and REL1_43 diverges in ways worth avoiding:

- **EmbedVideo** — `branch: REL1_43` + `86bbf18` → `branch: master` + `6982ef6` (v4.1.0). The code is identical to REL1_43 HEAD, but REL1_43 reports v4.0.0 — a confusing version downgrade on Special:Version for existing sites, for no functional change.
- **WSOAuth** — add `branch: master`, `77f5a37` → `602cd25` (v9.0.1). REL1_43 HEAD lacks the OAuth realname/email propagation in `MediaWikiAuth.php` that master has; this restores it.

Both require a MediaWiki version compatible with 1.43 (`>= 1.43.0`, `>= 1.35.0`).