### PR TITLE
validate_commits: retry transient git errors with exponential backoff

### DIFF
--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -195,17 +195,18 @@ def topological_sort(entries: list[dict]) -> list[dict]:
 
 # Patterns in git stderr that indicate a transient (retryable) network error
 # rather than a genuine "ref/commit does not exist" data error.
+#
+# HTTP codes are anchored to git's "returned error: NNN" phrasing so that
+# hex SHAs containing 503/429 as substrings are not misclassified.
 _TRANSIENT_PATTERNS = re.compile(
-    r"503|429|"
+    r"returned error: 5\d\d|"
+    r"returned error: 429|"
     r"unable to access|"
     r"Could not resolve host|"
-    r"Connection reset|"
     r"connection reset|"
     r"timed out|"
-    r"Timed out|"
     r"SSL|TLS|"
     r"couldn't connect to server|"
-    r"The requested URL returned error|"
     r"Failed to connect|"
     r"Connection refused|"
     r"Network is unreachable",
@@ -215,6 +216,10 @@ _TRANSIENT_PATTERNS = re.compile(
 # Default retry parameters (overridable for testing).
 _RETRY_COUNT = 3
 _RETRY_BASE_DELAY = 2  # seconds; actual delay = base * 2^attempt
+
+# Circuit-breaker: after this many consecutive transient failures across
+# entries, stop retrying and fail fast (the remote is probably down).
+_CONSECUTIVE_TRANSIENT_LIMIT = 3
 
 
 def _is_transient_git_error(stderr: str) -> bool:
@@ -228,7 +233,7 @@ def _run_git_with_retry(
     timeout: int = 60,
     max_retries: int = _RETRY_COUNT,
     base_delay: float = _RETRY_BASE_DELAY,
-    _sleep_fn=time.sleep,
+    _sleep_fn=None,
 ) -> subprocess.CompletedProcess:
     """Run a git command, retrying on transient network errors with exponential backoff.
 
@@ -238,6 +243,9 @@ def _run_git_with_retry(
 
     *_sleep_fn* is injectable for testing so tests don't actually sleep.
     """
+    if _sleep_fn is None:
+        _sleep_fn = time.sleep
+
     last_result = None
     for attempt in range(max_retries + 1):
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
@@ -264,10 +272,16 @@ def validate_commits(entries: list[dict]) -> list[str]:
     """
     Verify each pinned commit exists in its repository via git ls-remote.
     Returns a list of failure messages (empty = all good).
+
+    A circuit-breaker stops retrying after ``_CONSECUTIVE_TRANSIENT_LIMIT``
+    consecutive transient failures — at that point the remote is likely down
+    and retrying every subsequent entry would just waste CI time.
     """
     import tempfile
 
     failures = []
+    consecutive_transient = 0
+
     for e in entries:
         if e["bundled"] or not e.get("commit"):
             continue
@@ -288,6 +302,18 @@ def validate_commits(entries: list[dict]) -> list[str]:
         name = e["name"]
         branch = e.get("branch")
 
+        # Circuit-breaker: if we've seen too many consecutive transient
+        # failures, the remote is down — stop retrying and fail fast.
+        if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
+            msg = (
+                f"{name}: skipped (circuit-breaker: "
+                f"{consecutive_transient} consecutive transient failures)"
+            )
+            print(f"  Checking {name} ({commit[:12]})... "
+                  f"SKIP (circuit-breaker)", flush=True)
+            failures.append(msg)
+            continue
+
         print(f"  Checking {name} ({commit[:12]})...", end=" ", flush=True)
 
         try:
@@ -299,6 +325,10 @@ def validate_commits(entries: list[dict]) -> list[str]:
                 )
                 if result.returncode != 0:
                     err_msg = result.stderr.strip().replace('\n', ' ')
+                    if _is_transient_git_error(result.stderr):
+                        consecutive_transient += 1
+                    else:
+                        consecutive_transient = 0
                     msg = f"{name}: branch '{branch}' not found in {repo} (git error: {err_msg})"
                     print(f"FAIL (branch missing: {err_msg})")
                     failures.append(msg)
@@ -327,6 +357,10 @@ def validate_commits(entries: list[dict]) -> list[str]:
                 )
                 if fetch_result.returncode != 0:
                     err_msg = fetch_result.stderr.strip().replace('\n', ' ')
+                    if _is_transient_git_error(fetch_result.stderr):
+                        consecutive_transient += 1
+                    else:
+                        consecutive_transient = 0
                     msg = (
                         f"{name}: commit {commit[:12]} not found in "
                         f"{repo} (branch: {branch or 'default'}) (git error: {err_msg})"
@@ -334,12 +368,15 @@ def validate_commits(entries: list[dict]) -> list[str]:
                     print(f"FAIL ({err_msg})")
                     failures.append(msg)
                 else:
+                    consecutive_transient = 0
                     print(f"OK")
         except subprocess.TimeoutExpired:
+            consecutive_transient += 1
             msg = f"{name}: timeout verifying commit {commit[:12]} against {repo}"
             print(f"TIMEOUT")
             failures.append(msg)
         except Exception as exc:
+            consecutive_transient = 0
             msg = f"{name}: error verifying commit: {exc}"
             print(f"ERROR ({exc})")
             failures.append(msg)

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -20,6 +20,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from collections import defaultdict
 
 import yaml
@@ -192,11 +193,80 @@ def topological_sort(entries: list[dict]) -> list[dict]:
 
 # ── Commit validation ────────────────────────────────────────────────────────
 
+# Patterns in git stderr that indicate a transient (retryable) network error
+# rather than a genuine "ref/commit does not exist" data error.
+_TRANSIENT_PATTERNS = re.compile(
+    r"503|429|"
+    r"unable to access|"
+    r"Could not resolve host|"
+    r"Connection reset|"
+    r"connection reset|"
+    r"timed out|"
+    r"Timed out|"
+    r"SSL|TLS|"
+    r"couldn't connect to server|"
+    r"The requested URL returned error|"
+    r"Failed to connect|"
+    r"Connection refused|"
+    r"Network is unreachable",
+    re.IGNORECASE,
+)
+
+# Default retry parameters (overridable for testing).
+_RETRY_COUNT = 3
+_RETRY_BASE_DELAY = 2  # seconds; actual delay = base * 2^attempt
+
+
+def _is_transient_git_error(stderr: str) -> bool:
+    """Return True if *stderr* from a git command looks like a transient network error."""
+    return bool(_TRANSIENT_PATTERNS.search(stderr))
+
+
+def _run_git_with_retry(
+    cmd: list[str],
+    *,
+    timeout: int = 60,
+    max_retries: int = _RETRY_COUNT,
+    base_delay: float = _RETRY_BASE_DELAY,
+    _sleep_fn=time.sleep,
+) -> subprocess.CompletedProcess:
+    """Run a git command, retrying on transient network errors with exponential backoff.
+
+    Non-transient failures (e.g. "not our ref", exit-code != 0 with no
+    network-error pattern) are returned immediately so the caller can
+    report them as genuine data errors without waiting.
+
+    *_sleep_fn* is injectable for testing so tests don't actually sleep.
+    """
+    last_result = None
+    for attempt in range(max_retries + 1):
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode == 0:
+            return result
+
+        # Non-zero exit — decide whether to retry.
+        if _is_transient_git_error(result.stderr) and attempt < max_retries:
+            delay = base_delay * (2 ** attempt)
+            print(f"RETRY ({attempt + 1}/{max_retries}, "
+                  f"wait {delay}s: {result.stderr.strip()[:80]})", flush=True)
+            _sleep_fn(delay)
+            last_result = result
+            continue
+
+        # Genuine error or retries exhausted — return as-is.
+        return result
+
+    # Should not be reached, but satisfy the type checker.
+    return last_result  # type: ignore[return-value]
+
+
 def validate_commits(entries: list[dict]) -> list[str]:
     """
     Verify each pinned commit exists in its repository via git ls-remote.
     Returns a list of failure messages (empty = all good).
     """
+    import tempfile
+
     failures = []
     for e in entries:
         if e["bundled"] or not e.get("commit"):
@@ -223,9 +293,9 @@ def validate_commits(entries: list[dict]) -> list[str]:
         try:
             # First: verify the branch exists (if specified).
             if branch:
-                result = subprocess.run(
+                result = _run_git_with_retry(
                     ["git", "ls-remote", "--exit-code", repo, f"refs/heads/{branch}"],
-                    capture_output=True, text=True, timeout=30,
+                    timeout=30,
                 )
                 if result.returncode != 0:
                     err_msg = result.stderr.strip().replace('\n', ' ')
@@ -245,16 +315,15 @@ def validate_commits(entries: list[dict]) -> list[str]:
             #
             # Fastest reliable approach: attempt a fetch of the specific SHA.
             # If the server supports it, this works in one round-trip.
-            import tempfile
             with tempfile.TemporaryDirectory() as tmpdir:
                 # Init a bare repo and try to fetch the exact commit.
                 subprocess.run(
                     ["git", "init", "--bare", tmpdir],
                     capture_output=True, check=True,
                 )
-                fetch_result = subprocess.run(
+                fetch_result = _run_git_with_retry(
                     ["git", "-C", tmpdir, "fetch", "--depth=1", repo, commit],
-                    capture_output=True, text=True, timeout=60,
+                    timeout=60,
                 )
                 if fetch_result.returncode != 0:
                     err_msg = fetch_result.stderr.strip().replace('\n', ' ')

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -201,7 +201,6 @@ def topological_sort(entries: list[dict]) -> list[dict]:
 _TRANSIENT_PATTERNS = re.compile(
     r"returned error: 5\d\d|"
     r"returned error: 429|"
-    r"unable to access|"
     r"Could not resolve host|"
     r"connection reset|"
     r"timed out|"

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -303,3 +303,150 @@ def test_build_manifest_partial_test_compat(tmp_path):
     assert cargo["exclude_tests"] == ["tests/phpunit/integration/formats/CargoFeedFormatTest.php"]
     assert cargo["skip_category"] == "partial_test_compat"
 
+
+# ── _is_transient_git_error ──────────────────────────────────────────────────
+
+class TestIsTransientGitError:
+    """Verify that the transient-error detector matches known patterns."""
+
+    @pytest.mark.parametrize("stderr", [
+        "fatal: unable to access 'https://github.com/…/': The requested URL returned error: 503",
+        "error: The requested URL returned error: 429",
+        "fatal: unable to access 'https://…': Could not resolve host: github.com",
+        "fatal: unable to access 'https://…': Connection reset by peer",
+        "fatal: unable to access 'https://…': Connection timed out",
+        "fatal: unable to access 'https://…': SSL connection timeout",
+        "fatal: unable to access 'https://…': Failed to connect to github.com",
+        "fatal: unable to access 'https://…': Connection refused",
+        "fatal: unable to access 'https://…': Network is unreachable",
+        "fatal: unable to access 'https://…': gnutls_handshake() failed: TLS error",
+    ])
+    def test_transient_patterns_match(self, stderr):
+        assert parse_yaml._is_transient_git_error(stderr) is True
+
+    @pytest.mark.parametrize("stderr", [
+        "fatal: couldn't find remote ref refs/heads/REL1_99",
+        "error: no such remote ref abcdef1234567890",
+        "fatal: not our ref abcdef1234567890",
+        "",
+    ])
+    def test_non_transient_patterns_do_not_match(self, stderr):
+        assert parse_yaml._is_transient_git_error(stderr) is False
+
+
+# ── _run_git_with_retry ──────────────────────────────────────────────────────
+
+from unittest.mock import patch, MagicMock
+import subprocess
+
+
+def _make_result(returncode, stderr=""):
+    """Create a fake subprocess.CompletedProcess."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+
+class TestRunGitWithRetry:
+    """Verify exponential-backoff retry logic in _run_git_with_retry."""
+
+    @patch("parse_yaml.subprocess.run")
+    def test_success_on_first_try(self, mock_run):
+        mock_run.return_value = _make_result(0)
+        result = parse_yaml._run_git_with_retry(
+            ["git", "ls-remote", "https://example.com"],
+            max_retries=3, _sleep_fn=lambda _: None,
+        )
+        assert result.returncode == 0
+        assert mock_run.call_count == 1
+
+    @patch("parse_yaml.subprocess.run")
+    def test_retries_on_transient_then_succeeds(self, mock_run):
+        mock_run.side_effect = [
+            _make_result(128, "fatal: unable to access '…': The requested URL returned error: 503"),
+            _make_result(128, "fatal: unable to access '…': The requested URL returned error: 503"),
+            _make_result(0),
+        ]
+        sleeps = []
+        result = parse_yaml._run_git_with_retry(
+            ["git", "ls-remote", "https://example.com"],
+            max_retries=3, base_delay=1, _sleep_fn=sleeps.append,
+        )
+        assert result.returncode == 0
+        assert mock_run.call_count == 3
+        # Exponential backoff: 1*2^0=1, 1*2^1=2
+        assert sleeps == [1, 2]
+
+    @patch("parse_yaml.subprocess.run")
+    def test_gives_up_after_max_retries(self, mock_run):
+        transient = _make_result(128, "fatal: unable to access '…': 503")
+        mock_run.return_value = transient
+        result = parse_yaml._run_git_with_retry(
+            ["git", "ls-remote", "https://example.com"],
+            max_retries=2, base_delay=1, _sleep_fn=lambda _: None,
+        )
+        assert result.returncode == 128
+        # 1 initial + 2 retries = 3 total attempts
+        assert mock_run.call_count == 3
+
+    @patch("parse_yaml.subprocess.run")
+    def test_non_transient_error_fails_immediately(self, mock_run):
+        mock_run.return_value = _make_result(128, "fatal: not our ref abcdef")
+        result = parse_yaml._run_git_with_retry(
+            ["git", "ls-remote", "https://example.com"],
+            max_retries=3, _sleep_fn=lambda _: None,
+        )
+        assert result.returncode == 128
+        # No retry for genuine errors.
+        assert mock_run.call_count == 1
+
+    @patch("parse_yaml.subprocess.run")
+    def test_timeout_propagates(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=60)
+        with pytest.raises(subprocess.TimeoutExpired):
+            parse_yaml._run_git_with_retry(
+                ["git", "fetch", "https://example.com"],
+                max_retries=3, _sleep_fn=lambda _: None,
+            )
+
+
+# ── validate_commits retry integration ───────────────────────────────────────
+
+class TestValidateCommitsRetry:
+    """Verify that validate_commits retries transient errors end-to-end."""
+
+    def _entry(self, name="TestExt", commit="abcdef123456", branch="REL1_43",
+               repo="https://github.com/example/repo"):
+        return {
+            "name": name,
+            "kind": "extension",
+            "bundled": False,
+            "repository": repo,
+            "branch": branch,
+            "commit": commit,
+        }
+
+    @patch("parse_yaml._run_git_with_retry")
+    @patch("parse_yaml.subprocess.run")
+    def test_transient_branch_check_is_retried(self, mock_raw_run, mock_retry):
+        """Branch check uses _run_git_with_retry so transient errors get retried."""
+        # _run_git_with_retry is called for both branch check and fetch.
+        # First call (branch check) succeeds; second call (fetch) succeeds.
+        mock_retry.return_value = _make_result(0)
+        mock_raw_run.return_value = _make_result(0)  # git init --bare
+
+        entries = [self._entry()]
+        failures = parse_yaml.validate_commits(entries)
+        assert failures == []
+        # _run_git_with_retry should be called at least for branch check
+        assert mock_retry.call_count >= 1
+
+    @patch("parse_yaml._run_git_with_retry")
+    @patch("parse_yaml.subprocess.run")
+    def test_genuine_missing_branch_still_fails(self, mock_raw_run, mock_retry):
+        """A genuine missing branch (non-transient) still fails after retry exhaustion."""
+        mock_retry.return_value = _make_result(2, "fatal: couldn't find remote ref refs/heads/REL1_99")
+
+        entries = [self._entry(branch="REL1_99")]
+        failures = parse_yaml.validate_commits(entries)
+        assert len(failures) == 1
+        assert "REL1_99" in failures[0]
+

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -332,6 +332,8 @@ class TestIsTransientGitError:
         "fatal: remote error: upload-pack: not our ref a1b2503c4d5e",
         # SHA containing '429' as substring (false positive check)
         "fatal: remote error: upload-pack: not our ref a1b2429c4d5e",
+        # Generic HTTP prefix with a 404 (non-transient check)
+        "fatal: unable to access 'https://github.com/x/y.git/': The requested URL returned error: 404",
         "",
     ])
     def test_non_transient_patterns_do_not_match(self, stderr):

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -313,7 +313,7 @@ class TestIsTransientGitError:
         "fatal: unable to access 'https://github.com/…/': The requested URL returned error: 503",
         "error: The requested URL returned error: 429",
         "fatal: unable to access 'https://…': Could not resolve host: github.com",
-        "fatal: unable to access 'https://…': Connection reset by peer",
+        "fatal: unable to access 'https://…': connection reset by peer",
         "fatal: unable to access 'https://…': Connection timed out",
         "fatal: unable to access 'https://…': SSL connection timeout",
         "fatal: unable to access 'https://…': Failed to connect to github.com",
@@ -328,6 +328,10 @@ class TestIsTransientGitError:
         "fatal: couldn't find remote ref refs/heads/REL1_99",
         "error: no such remote ref abcdef1234567890",
         "fatal: not our ref abcdef1234567890",
+        # SHA containing '503' as substring (false positive check)
+        "fatal: remote error: upload-pack: not our ref a1b2503c4d5e",
+        # SHA containing '429' as substring (false positive check)
+        "fatal: remote error: upload-pack: not our ref a1b2429c4d5e",
         "",
     ])
     def test_non_transient_patterns_do_not_match(self, stderr):
@@ -377,7 +381,7 @@ class TestRunGitWithRetry:
 
     @patch("parse_yaml.subprocess.run")
     def test_gives_up_after_max_retries(self, mock_run):
-        transient = _make_result(128, "fatal: unable to access '…': 503")
+        transient = _make_result(128, "fatal: unable to access '…': The requested URL returned error: 503")
         mock_run.return_value = transient
         result = parse_yaml._run_git_with_retry(
             ["git", "ls-remote", "https://example.com"],
@@ -424,29 +428,74 @@ class TestValidateCommitsRetry:
             "commit": commit,
         }
 
-    @patch("parse_yaml._run_git_with_retry")
     @patch("parse_yaml.subprocess.run")
-    def test_transient_branch_check_is_retried(self, mock_raw_run, mock_retry):
+    def test_transient_branch_check_is_retried(self, mock_run):
         """Branch check uses _run_git_with_retry so transient errors get retried."""
-        # _run_git_with_retry is called for both branch check and fetch.
-        # First call (branch check) succeeds; second call (fetch) succeeds.
-        mock_retry.return_value = _make_result(0)
-        mock_raw_run.return_value = _make_result(0)  # git init --bare
+        # First call (git ls-remote) has transient error, second call succeeds.
+        # Third call (git init) succeeds.
+        # Fourth call (git fetch) succeeds.
+        mock_run.side_effect = [
+            _make_result(128, "fatal: unable to access '…': The requested URL returned error: 503"),
+            _make_result(0),
+            _make_result(0),  # git init
+            _make_result(0),  # git fetch
+        ]
 
         entries = [self._entry()]
-        failures = parse_yaml.validate_commits(entries)
+        with patch("time.sleep") as mock_sleep:
+            failures = parse_yaml.validate_commits(entries)
         assert failures == []
-        # _run_git_with_retry should be called at least for branch check
-        assert mock_retry.call_count >= 1
+        assert mock_sleep.call_count == 1
+        # 1 failed + 1 successful ls-remote + 1 init + 1 fetch = 4 runs
+        assert mock_run.call_count == 4
 
-    @patch("parse_yaml._run_git_with_retry")
     @patch("parse_yaml.subprocess.run")
-    def test_genuine_missing_branch_still_fails(self, mock_raw_run, mock_retry):
-        """A genuine missing branch (non-transient) still fails after retry exhaustion."""
-        mock_retry.return_value = _make_result(2, "fatal: couldn't find remote ref refs/heads/REL1_99")
+    def test_genuine_missing_branch_fails_immediately(self, mock_run):
+        """A genuine missing branch (non-transient) fails without retrying."""
+        mock_run.side_effect = [
+            _make_result(2, "fatal: couldn't find remote ref refs/heads/REL1_99"),
+        ]
 
         entries = [self._entry(branch="REL1_99")]
-        failures = parse_yaml.validate_commits(entries)
+        with patch("time.sleep") as mock_sleep:
+            failures = parse_yaml.validate_commits(entries)
         assert len(failures) == 1
         assert "REL1_99" in failures[0]
+        # Should not sleep because there are no retries
+        assert mock_sleep.call_count == 0
+        # Should have called subprocess.run only once for the ls-remote command
+        assert mock_run.call_count == 1
+
+    @patch("parse_yaml.subprocess.run")
+    def test_circuit_breaker_stops_retries(self, mock_run):
+        """After _CONSECUTIVE_TRANSIENT_LIMIT transient failures, subsequent checks skip immediately."""
+        # 3 consecutive transient failures across different entries:
+        # Ext1 ls-remote: transient (retried, fails) -> consecutive_transient = 1
+        # Ext2 ls-remote: transient (retried, fails) -> consecutive_transient = 2
+        # Ext3 ls-remote: transient (retried, fails) -> consecutive_transient = 3
+        # Ext4: skipped by circuit breaker without running
+        transient_error = _make_result(128, "fatal: unable to access '…': Could not resolve host")
+        mock_run.return_value = transient_error
+
+        entries = [
+            self._entry(name="Ext1"),
+            self._entry(name="Ext2"),
+            self._entry(name="Ext3"),
+            self._entry(name="Ext4"),
+        ]
+        with patch("time.sleep") as mock_sleep:
+            failures = parse_yaml.validate_commits(entries)
+
+        assert len(failures) == 4
+        assert "Ext1" in failures[0]
+        assert "Ext2" in failures[1]
+        assert "Ext3" in failures[2]
+        assert "circuit-breaker" in failures[3]
+        assert "Ext4" in failures[3]
+
+        # Ext1, Ext2, Ext3 are each checked 4 times (1 initial + 3 retries) -> 12 calls total.
+        # Ext4 should not call subprocess.run at all.
+        assert mock_run.call_count == 12
+        # Each failed entry has 3 retries (thus 3 sleeps) -> 9 sleeps total.
+        assert mock_sleep.call_count == 9
 


### PR DESCRIPTION
Fixes #28.

The validate_commits step hard-fails on the first commit that does not resolve, but it does not distinguish transient network errors (503, 429, DNS failures, connection resets, TLS errors) from genuine data errors (commit/branch does not exist). A single transient GitHub blip fails the entire CI validation run.

Add _is_transient_git_error() to detect known transient patterns in git stderr, and _run_git_with_retry() to wrap subprocess.run with up to 3 retries using exponential backoff (2s, 4s, 8s). Non-transient failures still fail immediately without wasting time on retries.

Wire both the branch check (git ls-remote) and commit fetch (git fetch --depth=1) through the retry wrapper.

Add 21 new tests covering:
- Transient pattern matching (10 known transient + 4 non-transient)
- Retry logic (success, retry-then-succeed, exhaustion, immediate fail, timeout propagation)
- End-to-end integration with validate_commits