### PR TITLE
Bump CrawlerProtection for MediaWiki 1.43 to v. 1.5.0

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -139,7 +139,7 @@ extensions:
 - CrawlerProtection:
     Wikidata ID: Q135293666
     repository: https://github.com/mywikis/CrawlerProtection
-    commit: ca5f8e993134846a609d2e09da00bbe232adb82a # v. 1.3.0
+    commit: 0da95035d6e99fbf2578f4ac29fe40bd8d743f4f # v. 1.5.0
 - CreateRedirect:
     Wikidata ID: Q21676753
     commit: 17f4ab36038cdf7d568bd17dcf8ebc2110c9dcb9


### PR DESCRIPTION
Fixes #32.

Bumps the MediaWiki 1.43 pin for CrawlerProtection from `ca5f8e99` (v. 1.3.0) to `0da95035d6e99fbf2578f4ac29fe40bd8d743f4f` (v. 1.5.0).

v. 1.5.0 fixes a crawler pattern that saturated a production Canasta wiki: special-page filter parameters sent to `index.php` without a `title` never reach `SpecialPageBeforeExecute`, so MediaWiki renders the main page instead, and because each URL is unique they defeat CDN and reverse-proxy caching.

## What the bump carries

| Version | Change | Config added |
| --- | --- | --- |
| 1.4.0 `703b6ab` | IP ranges may bypass all protections (mywikis/CrawlerProtection#28) | `$wgCrawlerProtectionAllowedIPs`, default `[]` |
| 1.4.1 `42da480` | Local values replace extension defaults instead of merging; revision/diff blocking decoupled from history (mywikis/CrawlerProtection#30) | `$wgCrawlerProtectionProtectRevisions`, default `true` |
| 1.5.0 `0da9503` | Deny special-page query parameters sent without a `title` (mywikis/CrawlerProtection#36) | `$wgCrawlerProtectedQueryParams`, default `[ 'target' ]` |

`8670c68` (author hyperlink) and `9c0dff2` (CI) carry no runtime change.

## Behavior changes on upgrade

**1.4.1 added `merge_strategy: provide_default`** to `$wgCrawlerProtectedActions`, `$wgCrawlerProtectedSpecialPages` and `$wgCrawlerProtectionAllowedIPs`. Previously the extension defaults merged with a wiki's values, so a default entry could not be removed. With `$wgCrawlerProtectedActions = [ 'edit' ]`:

| | runtime value | `action=history` |
| --- | --- | --- |
| 1.3.0 | `[ 'history', 'edit' ]` | 403 |
| 1.5.0 | `[ 'edit' ]` | 200 |

Wikis that customized any of those three settings should re-add default entries they still want.

**1.5.0** denies anonymous requests carrying `target` with no `title`.

`$wgCrawlerProtectionProtectRevisions` defaults to `true`, so `oldid`/`diff` blocking is unchanged.

## Verification

```
python3 scripts/parse_yaml.py 1.43.yaml --validate
  All required extension dependencies are satisfied.

python3 scripts/parse_yaml.py 1.43.yaml --validate-commits
  Checking CrawlerProtection (0da95035d6e9)... OK
  ✅ All 174 entries have valid commits.
```

The upgrade behavior above was tested on MediaWiki 1.43 / PHP 8.2 with the extension at `0da9503`.

`1.39.yaml` and `1.44.yaml` also pin `ca5f8e99`; only 1.43 is validated here.
