### PR TITLE
Update CrawlerProtection to v. 1.7.0 in 1.43.yaml

### DIFF
--- a/1.43.yaml
+++ b/1.43.yaml
@@ -139,7 +139,7 @@ extensions:
 - CrawlerProtection:
     Wikidata ID: Q135293666
     repository: https://github.com/mywikis/CrawlerProtection
-    commit: 0da95035d6e99fbf2578f4ac29fe40bd8d743f4f # v. 1.5.0
+    commit: c72eec320f87776a21deedf9147e8f9eae335fd0 # v. 1.7.0
 - CreateRedirect:
     Wikidata ID: Q21676753
     commit: 17f4ab36038cdf7d568bd17dcf8ebc2110c9dcb9


### PR DESCRIPTION
Moves the CrawlerProtection pin in `1.43.yaml` from `0da9503` (v. 1.5.0) to `c72eec3`, the 1.7.0 release commit.

The repository publishes no tags, so the version-bump commit is the pin. The only commit after it on `main` (`0910c11`) adds SAST scanning to CI and does not change shipped code.

Picked up since 1.5.0:

- Protection is skipped in CLI and maintenance context, so a maintenance script re-parsing a page that transcludes a protected special page no longer denies itself.
- `api.php` and `rest.php` entry points are protected.
- Denial responses are localised and marked `noindex,nofollow`.
- New `CrawlerProtectionShouldDeny` hook for a bespoke access policy.

Still requires MediaWiki >= 1.39.4, so 1.43 remains supported.

## Verified

```
scripts/parse_yaml.py 1.43.yaml --validate          174 entries, all required dependencies satisfied
scripts/parse_yaml.py 1.43.yaml --validate-commits  ✅ All 174 entries have valid commits
```

Fixes #35
