### PR TITLE
validate_commits: harden transient-error handling (follow-up to #29)

### DIFF
--- a/.ci/install_extensions.sh
+++ b/.ci/install_extensions.sh
@@ -143,11 +143,13 @@ for entry in entries:
         elif step == "composer update":
             if os.path.isfile(os.path.join(target_dir, "composer.json")):
                 print(f"  COMPOSER  {name}")
-                subprocess.run(
+                result = subprocess.run(
                     ["composer", "update", "--no-interaction", "--no-progress",
                      "--prefer-dist", "--no-dev"],
-                    cwd=target_dir, capture_output=True, check=False,
+                    cwd=target_dir, capture_output=True, text=True, check=False,
                 )
+                if result.returncode != 0:
+                    print(f"    COMPOSER ERROR for {name}: {result.stderr.strip()}")
         elif step == "git submodule update":
             print(f"  SUBMODULE {name}")
             subprocess.run(

--- a/.ci/skip_list.yaml
+++ b/.ci/skip_list.yaml
@@ -114,6 +114,10 @@ upstream_test_compat:
     reason: Requires onoi/cache library in isolated PHPUnit environment
   - name: SemanticDependencyUpdater
     reason: Dependency on SMW vendor libraries in isolated PHPUnit environment
+  - name: AntiSpoof
+    reason: Integration test suite errors under MediaWiki 1.43 / PHP 8.3
+  - name: TimedMediaHandler
+    reason: Integration test suite errors / FFmpeg dependencies under MediaWiki 1.43
 
 # ── Extensions with partial test exclusions ──────────────────────────────────
 # These extensions pass the vast majority of their test suite. Only a few

--- a/.ci/skip_list.yaml
+++ b/.ci/skip_list.yaml
@@ -108,6 +108,12 @@ upstream_test_compat:
     reason: Integration test suite errors / dependency on SMW test classes
   - name: SemanticScribunto
     reason: Integration test suite errors / dependency on SMW test classes
+  - name: OATHAuth
+    reason: Requires christian-riesen/base32 library in isolated PHPUnit environment
+  - name: SemanticMediaWiki
+    reason: Requires onoi/cache library in isolated PHPUnit environment
+  - name: SemanticDependencyUpdater
+    reason: Dependency on SMW vendor libraries in isolated PHPUnit environment
 
 # ── Extensions with partial test exclusions ──────────────────────────────────
 # These extensions pass the vast majority of their test suite. Only a few

--- a/.ci/skip_list.yaml
+++ b/.ci/skip_list.yaml
@@ -108,16 +108,6 @@ upstream_test_compat:
     reason: Integration test suite errors / dependency on SMW test classes
   - name: SemanticScribunto
     reason: Integration test suite errors / dependency on SMW test classes
-  - name: OATHAuth
-    reason: Requires christian-riesen/base32 library in isolated PHPUnit environment
-  - name: SemanticMediaWiki
-    reason: Requires onoi/cache library in isolated PHPUnit environment
-  - name: SemanticDependencyUpdater
-    reason: Dependency on SMW vendor libraries in isolated PHPUnit environment
-  - name: AntiSpoof
-    reason: Integration test suite errors under MediaWiki 1.43 / PHP 8.3
-  - name: TimedMediaHandler
-    reason: Integration test suite errors / FFmpeg dependencies under MediaWiki 1.43
 
 # ── Extensions with partial test exclusions ──────────────────────────────────
 # These extensions pass the vast majority of their test suite. Only a few

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   parse:
     name: Parse & Validate Commits
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
       coexistence_matrix: ${{ steps.coexistence.outputs.matrix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,11 +308,13 @@ jobs:
                   elif step == "composer update":
                       if os.path.isfile(os.path.join(target_dir, "composer.json")):
                           print(f"  COMPOSER  {name}")
-                          subprocess.run(
+                          result = subprocess.run(
                               ["composer", "update", "--no-interaction", "--no-progress",
                                "--prefer-dist", "--no-dev"],
-                              cwd=target_dir, capture_output=True, check=False,
+                              cwd=target_dir, capture_output=True, text=True, check=False,
                           )
+                          if result.returncode != 0:
+                              print(f"    COMPOSER ERROR for {name}: {result.stderr.strip()}")
                   elif step == "git submodule update":
                       print(f"  SUBMODULE {name}")
                       subprocess.run(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
   parse:
     name: Parse & Validate Commits
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
       coexistence_matrix: ${{ steps.coexistence.outputs.matrix }}

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -20,6 +20,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from collections import defaultdict
 
@@ -204,11 +205,16 @@ _TRANSIENT_PATTERNS = re.compile(
     r"Could not resolve host|"
     r"connection reset|"
     r"timed out|"
-    r"SSL|TLS|"
+    r"gnutls|SSL connection timeout|SSL certificate problem|SSL_ERROR|TLS handshake|TLS connection reset|TLS error|"
     r"couldn't connect to server|"
     r"Failed to connect|"
     r"Connection refused|"
-    r"Network is unreachable",
+    r"Network is unreachable|"
+    r"the remote end hung up unexpectedly|"
+    r"RPC failed|"
+    r"early EOF|"
+    r"Empty reply from server|"
+    r"Error in the HTTP2 framing layer",
     re.IGNORECASE,
 )
 
@@ -232,6 +238,7 @@ def _run_git_with_retry(
     timeout: int = 60,
     max_retries: int = _RETRY_COUNT,
     base_delay: float = _RETRY_BASE_DELAY,
+    retry_prefix: str | None = None,
     _sleep_fn=None,
 ) -> subprocess.CompletedProcess:
     """Run a git command, retrying on transient network errors with exponential backoff.
@@ -245,26 +252,38 @@ def _run_git_with_retry(
     if _sleep_fn is None:
         _sleep_fn = time.sleep
 
-    last_result = None
+    last_exception = None
     for attempt in range(max_retries + 1):
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-        if result.returncode == 0:
-            return result
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if result.returncode == 0:
+                return result
 
-        # Non-zero exit — decide whether to retry.
-        if _is_transient_git_error(result.stderr) and attempt < max_retries:
+            # Non-zero exit — decide whether to retry.
+            stderr_to_check = result.stderr
+            is_transient = _is_transient_git_error(stderr_to_check)
+            err_details = stderr_to_check.strip()[:80]
+        except subprocess.TimeoutExpired as exc:
+            if attempt >= max_retries:
+                raise
+            result = None
+            is_transient = True
+            err_details = f"command timed out after {timeout}s"
+            last_exception = exc
+
+        if is_transient and attempt < max_retries:
             delay = base_delay * (2 ** attempt)
-            print(f"RETRY ({attempt + 1}/{max_retries}, "
-                  f"wait {delay}s: {result.stderr.strip()[:80]})", flush=True)
+            print(f"\n  RETRY ({attempt + 1}/{max_retries}, "
+                  f"wait {delay}s: {err_details})", flush=True)
             _sleep_fn(delay)
-            last_result = result
+            if retry_prefix:
+                print(retry_prefix, end="", flush=True)
             continue
 
-        # Genuine error or retries exhausted — return as-is.
-        return result
-
-    # Should not be reached, but satisfy the type checker.
-    return last_result  # type: ignore[return-value]
+        if result is not None:
+            return result
+        else:
+            raise last_exception
 
 
 def validate_commits(entries: list[dict]) -> list[str]:
@@ -276,10 +295,10 @@ def validate_commits(entries: list[dict]) -> list[str]:
     consecutive transient failures — at that point the remote is likely down
     and retrying every subsequent entry would just waste CI time.
     """
-    import tempfile
-
     failures = []
     consecutive_transient = 0
+    start_time = time.monotonic()
+    max_elapsed_seconds = 600
 
     for e in entries:
         if e["bundled"] or not e.get("commit"):
@@ -301,18 +320,22 @@ def validate_commits(entries: list[dict]) -> list[str]:
         name = e["name"]
         branch = e.get("branch")
 
+        # Total elapsed budget check
+        if time.monotonic() - start_time > max_elapsed_seconds:
+            msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
+            print(f"\n⚠️  {msg}", flush=True)
+            failures.append(msg)
+            break
+
         # Circuit-breaker: if we've seen too many consecutive transient
         # failures, the remote is down — stop retrying and fail fast.
         if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
-            msg = (
-                f"{name}: skipped (circuit-breaker: "
-                f"{consecutive_transient} consecutive transient failures)"
-            )
-            print(f"  Checking {name} ({commit[:12]})... "
-                  f"SKIP (circuit-breaker)", flush=True)
+            msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
+            print(f"\n⚠️  {msg}", flush=True)
             failures.append(msg)
-            continue
+            break
 
+        prefix = f"  Checking {name} ({commit[:12]})... "
         print(f"  Checking {name} ({commit[:12]})...", end=" ", flush=True)
 
         try:
@@ -321,6 +344,7 @@ def validate_commits(entries: list[dict]) -> list[str]:
                 result = _run_git_with_retry(
                     ["git", "ls-remote", "--exit-code", repo, f"refs/heads/{branch}"],
                     timeout=30,
+                    retry_prefix=prefix,
                 )
                 if result.returncode != 0:
                     err_msg = result.stderr.strip().replace('\n', ' ')
@@ -353,6 +377,7 @@ def validate_commits(entries: list[dict]) -> list[str]:
                 fetch_result = _run_git_with_retry(
                     ["git", "-C", tmpdir, "fetch", "--depth=1", repo, commit],
                     timeout=60,
+                    retry_prefix=prefix,
                 )
                 if fetch_result.returncode != 0:
                     err_msg = fetch_result.stderr.strip().replace('\n', ' ')

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import argparse
+import concurrent.futures
 import json
 import os
 import re
@@ -286,124 +287,159 @@ def _run_git_with_retry(
             raise last_exception
 
 
-def validate_commits(entries: list[dict]) -> list[str]:
+def _validate_single_entry(e: dict) -> tuple[str, bool, str, bool]:
     """
-    Verify each pinned commit exists in its repository via git ls-remote.
+    Validate a single extension/skin entry.
+    Returns (name, is_success, failure_message, is_transient_failure).
+    """
+    repo = e.get("repository")
+    if not repo:
+        return e["name"], True, "", False
+
+    # Map Gerrit URL to GitHub mirror to avoid HTTP 429 rate limits in CI.
+    if repo.startswith("https://gerrit.wikimedia.org/r/mediawiki/"):
+        parts = repo.split("/")
+        if len(parts) >= 7:
+            kind = parts[5]  # 'extensions' or 'skins'
+            name_part = parts[6]
+            repo = f"https://github.com/wikimedia/mediawiki-{kind}-{name_part}"
+
+    commit = e["commit"]
+    name = e["name"]
+    branch = e.get("branch")
+    prefix = f"  Checking {name} ({commit[:12]})... "
+
+    try:
+        # First: verify the branch exists (if specified).
+        if branch:
+            result = _run_git_with_retry(
+                ["git", "ls-remote", "--exit-code", repo, f"refs/heads/{branch}"],
+                timeout=30,
+            )
+            if result.returncode != 0:
+                err_msg = result.stderr.strip().replace('\n', ' ')
+                is_transient = _is_transient_git_error(result.stderr)
+                msg = f"{name}: branch '{branch}' not found in {repo} (git error: {err_msg})"
+                return name, False, msg, is_transient
+
+        # Second: fetch the specific commit SHA.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                ["git", "init", "--bare", tmpdir],
+                capture_output=True, check=True,
+            )
+            fetch_result = _run_git_with_retry(
+                ["git", "-C", tmpdir, "fetch", "--depth=1", repo, commit],
+                timeout=60,
+            )
+            if fetch_result.returncode != 0:
+                err_msg = fetch_result.stderr.strip().replace('\n', ' ')
+                is_transient = _is_transient_git_error(fetch_result.stderr)
+                msg = (
+                    f"{name}: commit {commit[:12]} not found in "
+                    f"{repo} (branch: {branch or 'default'}) (git error: {err_msg})"
+                )
+                return name, False, msg, is_transient
+            else:
+                return name, True, "OK", False
+    except subprocess.TimeoutExpired:
+        msg = f"{name}: timeout verifying commit {commit[:12]} against {repo}"
+        return name, False, msg, True
+    except Exception as exc:
+        msg = f"{name}: error verifying commit: {exc}"
+        return name, False, msg, False
+
+
+def validate_commits(entries: list[dict], max_workers: int = 16) -> list[str]:
+    """
+    Verify each pinned commit exists in its repository via git ls-remote and fetch.
     Returns a list of failure messages (empty = all good).
 
+    Runs in parallel using ThreadPoolExecutor for high performance.
     A circuit-breaker stops retrying after ``_CONSECUTIVE_TRANSIENT_LIMIT``
-    consecutive transient failures — at that point the remote is likely down
-    and retrying every subsequent entry would just waste CI time.
+    consecutive transient failures — at that point the remote is likely down.
     """
+    to_validate = [e for e in entries if not e.get("bundled") and e.get("commit") and e.get("repository")]
+    if not to_validate:
+        return []
+
     failures = []
     consecutive_transient = 0
     start_time = time.monotonic()
     max_elapsed_seconds = 600
 
-    for e in entries:
-        if e["bundled"] or not e.get("commit"):
-            continue
-        repo = e.get("repository")
-        if not repo:
-            continue
+    # Sequential execution fallback when max_workers == 1 (e.g. deterministic unit tests)
+    if max_workers == 1:
+        for e in to_validate:
+            if time.monotonic() - start_time > max_elapsed_seconds:
+                msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
+                print(f"\n⚠️  {msg}", flush=True)
+                failures.append(msg)
+                break
 
-        # If it's a Gerrit URL, map it to the GitHub mirror to avoid HTTP 429 rate limits in CI.
-        # This keeps the actual metadata using Gerrit but does validation against the fast GitHub mirror.
-        if repo.startswith("https://gerrit.wikimedia.org/r/mediawiki/"):
-            parts = repo.split("/")
-            if len(parts) >= 7:
-                kind = parts[5]  # 'extensions' or 'skins'
-                name_part = parts[6]  # extension/skin name
-                repo = f"https://github.com/wikimedia/mediawiki-{kind}-{name_part}"
+            if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
+                msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
+                print(f"\n⚠️  {msg}", flush=True)
+                failures.append(msg)
+                break
 
-        commit = e["commit"]
-        name = e["name"]
-        branch = e.get("branch")
+            name = e["name"]
+            commit = e["commit"]
+            prefix = f"  Checking {name} ({commit[:12]})... "
+            print(prefix, end="", flush=True)
 
-        # Total elapsed budget check
-        if time.monotonic() - start_time > max_elapsed_seconds:
-            msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
-            print(f"\n⚠️  {msg}", flush=True)
-            failures.append(msg)
-            break
-
-        # Circuit-breaker: if we've seen too many consecutive transient
-        # failures, the remote is down — stop retrying and fail fast.
-        if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
-            msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
-            print(f"\n⚠️  {msg}", flush=True)
-            failures.append(msg)
-            break
-
-        prefix = f"  Checking {name} ({commit[:12]})... "
-        print(f"  Checking {name} ({commit[:12]})...", end=" ", flush=True)
-
-        try:
-            # First: verify the branch exists (if specified).
-            if branch:
-                result = _run_git_with_retry(
-                    ["git", "ls-remote", "--exit-code", repo, f"refs/heads/{branch}"],
-                    timeout=30,
-                    retry_prefix=prefix,
-                )
-                if result.returncode != 0:
-                    err_msg = result.stderr.strip().replace('\n', ' ')
-                    if _is_transient_git_error(result.stderr):
-                        consecutive_transient += 1
-                    else:
-                        consecutive_transient = 0
-                    msg = f"{name}: branch '{branch}' not found in {repo} (git error: {err_msg})"
-                    print(f"FAIL (branch missing: {err_msg})")
-                    failures.append(msg)
-                    continue
-
-            # Second: try to find the commit.  ls-remote can't look up
-            # arbitrary SHAs directly, so we do a shallow clone check.
-            # For Gerrit repos, we can use the Gerrit REST API or just
-            # trust that if the branch exists, the commit is on it.
-            # For GitHub repos, we can use the API.
-            #
-            # Pragmatic approach: clone --depth=1 --branch, then verify
-            # the commit is an ancestor.  But that's slow for 170 repos.
-            #
-            # Fastest reliable approach: attempt a fetch of the specific SHA.
-            # If the server supports it, this works in one round-trip.
-            with tempfile.TemporaryDirectory() as tmpdir:
-                # Init a bare repo and try to fetch the exact commit.
-                subprocess.run(
-                    ["git", "init", "--bare", tmpdir],
-                    capture_output=True, check=True,
-                )
-                fetch_result = _run_git_with_retry(
-                    ["git", "-C", tmpdir, "fetch", "--depth=1", repo, commit],
-                    timeout=60,
-                    retry_prefix=prefix,
-                )
-                if fetch_result.returncode != 0:
-                    err_msg = fetch_result.stderr.strip().replace('\n', ' ')
-                    if _is_transient_git_error(fetch_result.stderr):
-                        consecutive_transient += 1
-                    else:
-                        consecutive_transient = 0
-                    msg = (
-                        f"{name}: commit {commit[:12]} not found in "
-                        f"{repo} (branch: {branch or 'default'}) (git error: {err_msg})"
-                    )
-                    print(f"FAIL ({err_msg})")
-                    failures.append(msg)
+            _, success, msg, is_transient = _validate_single_entry(e)
+            if success:
+                consecutive_transient = 0
+                print("OK", flush=True)
+            else:
+                if is_transient:
+                    consecutive_transient += 1
                 else:
                     consecutive_transient = 0
-                    print(f"OK")
-        except subprocess.TimeoutExpired:
-            consecutive_transient += 1
-            msg = f"{name}: timeout verifying commit {commit[:12]} against {repo}"
-            print(f"TIMEOUT")
-            failures.append(msg)
-        except Exception as exc:
-            consecutive_transient = 0
-            msg = f"{name}: error verifying commit: {exc}"
-            print(f"ERROR ({exc})")
-            failures.append(msg)
+                print(f"FAIL ({msg})", flush=True)
+                failures.append(msg)
+        return failures
+
+    # Parallel execution with ThreadPoolExecutor
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_entry = {executor.submit(_validate_single_entry, e): e for e in to_validate}
+        for future in concurrent.futures.as_completed(future_to_entry):
+            e = future_to_entry[future]
+            name = e["name"]
+            commit = e["commit"]
+
+            if time.monotonic() - start_time > max_elapsed_seconds:
+                msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
+                print(f"\n⚠️  {msg}", flush=True)
+                failures.append(msg)
+                executor.shutdown(wait=False, cancel_futures=True)
+                break
+
+            if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
+                msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
+                print(f"\n⚠️  {msg}", flush=True)
+                failures.append(msg)
+                executor.shutdown(wait=False, cancel_futures=True)
+                break
+
+            try:
+                _, success, msg, is_transient = future.result()
+                if success:
+                    consecutive_transient = 0
+                    print(f"  Checking {name} ({commit[:12]})... OK", flush=True)
+                else:
+                    if is_transient:
+                        consecutive_transient += 1
+                    else:
+                        consecutive_transient = 0
+                    print(f"  Checking {name} ({commit[:12]})... FAIL ({msg})", flush=True)
+                    failures.append(msg)
+            except Exception as exc:
+                consecutive_transient = 0
+                err_msg = f"{name}: error verifying commit: {exc}"
+                print(f"  Checking {name} ({commit[:12]})... ERROR ({exc})", flush=True)
+                failures.append(err_msg)
 
     return failures
 

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -22,6 +22,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections import defaultdict
 
@@ -212,7 +213,7 @@ _TRANSIENT_PATTERNS = re.compile(
     r"Connection refused|"
     r"Network is unreachable|"
     r"the remote end hung up unexpectedly|"
-    r"RPC failed|"
+    r"RPC failed; (?:curl|result=)|"
     r"early EOF|"
     r"Empty reply from server|"
     r"Error in the HTTP2 framing layer",
@@ -222,9 +223,9 @@ _TRANSIENT_PATTERNS = re.compile(
 # Default retry parameters (overridable for testing).
 _RETRY_COUNT = 3
 _RETRY_BASE_DELAY = 2  # seconds; actual delay = base * 2^attempt
+_MAX_ELAPSED_SECONDS = 600
 
-# Circuit-breaker: after this many consecutive transient failures across
-# entries, stop retrying and fail fast (the remote is probably down).
+# Circuit-breaker: after this many transient failures across entries, stop retrying and fail fast.
 _CONSECUTIVE_TRANSIENT_LIMIT = 3
 
 
@@ -239,7 +240,8 @@ def _run_git_with_retry(
     timeout: int = 60,
     max_retries: int = _RETRY_COUNT,
     base_delay: float = _RETRY_BASE_DELAY,
-    retry_prefix: str | None = None,
+    entry_name: str | None = None,
+    abort_event: threading.Event | None = None,
     _sleep_fn=None,
 ) -> subprocess.CompletedProcess:
     """Run a git command, retrying on transient network errors with exponential backoff.
@@ -253,8 +255,14 @@ def _run_git_with_retry(
     if _sleep_fn is None:
         _sleep_fn = time.sleep
 
+    result = None
     last_exception = None
     for attempt in range(max_retries + 1):
+        if abort_event and abort_event.is_set():
+            if last_exception:
+                raise last_exception
+            return subprocess.CompletedProcess(args=cmd, returncode=128, stdout="", stderr="Aborted due to circuit breaker")
+
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
             if result.returncode == 0:
@@ -273,28 +281,80 @@ def _run_git_with_retry(
             last_exception = exc
 
         if is_transient and attempt < max_retries:
+            if abort_event and abort_event.is_set():
+                if last_exception:
+                    raise last_exception
+                return result
+
             delay = base_delay * (2 ** attempt)
-            print(f"\n  RETRY ({attempt + 1}/{max_retries}, "
-                  f"wait {delay}s: {err_details})", flush=True)
+            name_str = f" for {entry_name}" if entry_name else ""
+            print(f"\n  RETRY{name_str} ({attempt + 1}/{max_retries}, wait {delay}s: {err_details})", flush=True)
             _sleep_fn(delay)
-            if retry_prefix:
-                print(retry_prefix, end="", flush=True)
             continue
 
         if result is not None:
             return result
-        else:
+        elif last_exception is not None:
             raise last_exception
 
+    return result
 
-def _validate_single_entry(e: dict) -> tuple[str, bool, str, bool]:
+
+class ValidationContext:
+    def __init__(self, total_count: int):
+        self.total_count = total_count
+        self.validated_count = 0
+        self.transient_count = 0
+        self.abort_event = threading.Event()
+        self.lock = threading.Lock()
+        self.start_time = time.monotonic()
+        self.abort_msg = ""
+
+    def record_result(self, is_success: bool, is_transient: bool):
+        with self.lock:
+            self.validated_count += 1
+            if not is_success and is_transient:
+                self.transient_count += 1
+                if self.transient_count >= _CONSECUTIVE_TRANSIENT_LIMIT and not self.abort_event.is_set():
+                    self.abort_event.set()
+                    unvalidated = self.total_count - self.validated_count
+                    self.abort_msg = (
+                        f"Validation aborted after {self.transient_count} transient failures "
+                        f"({unvalidated} of {self.total_count} entries unvalidated) — remote appears unreachable"
+                    )
+
+    def check_time_budget(self) -> bool:
+        if time.monotonic() - self.start_time > _MAX_ELAPSED_SECONDS:
+            with self.lock:
+                if not self.abort_event.is_set():
+                    self.abort_event.set()
+                    unvalidated = self.total_count - self.validated_count
+                    self.abort_msg = (
+                        f"Validation aborted: exceeded total elapsed time limit of {_MAX_ELAPSED_SECONDS}s "
+                        f"({unvalidated} of {self.total_count} entries unvalidated)"
+                    )
+            return True
+        return False
+
+
+def _validate_single_entry(
+    e: dict,
+    ctx: ValidationContext | None = None,
+    _sleep_fn=None,
+) -> tuple[str, bool, str, bool, bool]:
     """
     Validate a single extension/skin entry.
-    Returns (name, is_success, failure_message, is_transient_failure).
+    Returns (name, is_success, failure_message, is_transient_failure, is_aborted).
     """
+    name = e["name"]
+    if ctx and (ctx.abort_event.is_set() or ctx.check_time_budget()):
+        return name, False, "Aborted", False, True
+
     repo = e.get("repository")
     if not repo:
-        return e["name"], True, "", False
+        if ctx:
+            ctx.record_result(True, False)
+        return name, True, "", False, False
 
     # Map Gerrit URL to GitHub mirror to avoid HTTP 429 rate limits in CI.
     if repo.startswith("https://gerrit.wikimedia.org/r/mediawiki/"):
@@ -305,22 +365,34 @@ def _validate_single_entry(e: dict) -> tuple[str, bool, str, bool]:
             repo = f"https://github.com/wikimedia/mediawiki-{kind}-{name_part}"
 
     commit = e["commit"]
-    name = e["name"]
     branch = e.get("branch")
-    prefix = f"  Checking {name} ({commit[:12]})... "
+    abort_event = ctx.abort_event if ctx else None
 
     try:
+        if ctx and (ctx.abort_event.is_set() or ctx.check_time_budget()):
+            return name, False, "Aborted", False, True
+
         # First: verify the branch exists (if specified).
         if branch:
             result = _run_git_with_retry(
                 ["git", "ls-remote", "--exit-code", repo, f"refs/heads/{branch}"],
                 timeout=30,
+                entry_name=name,
+                abort_event=abort_event,
+                _sleep_fn=_sleep_fn,
             )
+            if abort_event and abort_event.is_set():
+                return name, False, "Aborted", False, True
             if result.returncode != 0:
                 err_msg = result.stderr.strip().replace('\n', ' ')
                 is_transient = _is_transient_git_error(result.stderr)
                 msg = f"{name}: branch '{branch}' not found in {repo} (git error: {err_msg})"
-                return name, False, msg, is_transient
+                if ctx:
+                    ctx.record_result(False, is_transient)
+                return name, False, msg, is_transient, False
+
+        if ctx and (ctx.abort_event.is_set() or ctx.check_time_budget()):
+            return name, False, "Aborted", False, True
 
         # Second: fetch the specific commit SHA.
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -331,7 +403,12 @@ def _validate_single_entry(e: dict) -> tuple[str, bool, str, bool]:
             fetch_result = _run_git_with_retry(
                 ["git", "-C", tmpdir, "fetch", "--depth=1", repo, commit],
                 timeout=60,
+                entry_name=name,
+                abort_event=abort_event,
+                _sleep_fn=_sleep_fn,
             )
+            if abort_event and abort_event.is_set():
+                return name, False, "Aborted", False, True
             if fetch_result.returncode != 0:
                 err_msg = fetch_result.stderr.strip().replace('\n', ' ')
                 is_transient = _is_transient_git_error(fetch_result.stderr)
@@ -339,107 +416,78 @@ def _validate_single_entry(e: dict) -> tuple[str, bool, str, bool]:
                     f"{name}: commit {commit[:12]} not found in "
                     f"{repo} (branch: {branch or 'default'}) (git error: {err_msg})"
                 )
-                return name, False, msg, is_transient
+                if ctx:
+                    ctx.record_result(False, is_transient)
+                return name, False, msg, is_transient, False
             else:
-                return name, True, "OK", False
+                if ctx:
+                    ctx.record_result(True, False)
+                return name, True, "OK", False, False
     except subprocess.TimeoutExpired:
         msg = f"{name}: timeout verifying commit {commit[:12]} against {repo}"
-        return name, False, msg, True
+        if ctx:
+            ctx.record_result(False, True)
+        return name, False, msg, True, False
     except Exception as exc:
         msg = f"{name}: error verifying commit: {exc}"
-        return name, False, msg, False
+        if ctx:
+            ctx.record_result(False, False)
+        return name, False, msg, False, False
 
 
-def validate_commits(entries: list[dict], max_workers: int = 16) -> list[str]:
+def validate_commits(entries: list[dict], max_workers: int = 16, _sleep_fn=None) -> list[str]:
     """
     Verify each pinned commit exists in its repository via git ls-remote and fetch.
     Returns a list of failure messages (empty = all good).
 
     Runs in parallel using ThreadPoolExecutor for high performance.
     A circuit-breaker stops retrying after ``_CONSECUTIVE_TRANSIENT_LIMIT``
-    consecutive transient failures — at that point the remote is likely down.
+    transient failures — at that point the remote is likely down.
     """
     to_validate = [e for e in entries if not e.get("bundled") and e.get("commit") and e.get("repository")]
     if not to_validate:
         return []
 
     failures = []
-    consecutive_transient = 0
-    start_time = time.monotonic()
-    max_elapsed_seconds = 600
+    ctx = ValidationContext(len(to_validate))
+    abort_reported = False
 
-    # Sequential execution fallback when max_workers == 1 (e.g. deterministic unit tests)
-    if max_workers == 1:
-        for e in to_validate:
-            if time.monotonic() - start_time > max_elapsed_seconds:
-                msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
-                print(f"\n⚠️  {msg}", flush=True)
-                failures.append(msg)
-                break
-
-            if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
-                msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
-                print(f"\n⚠️  {msg}", flush=True)
-                failures.append(msg)
-                break
-
-            name = e["name"]
-            commit = e["commit"]
-            prefix = f"  Checking {name} ({commit[:12]})... "
-            print(prefix, end="", flush=True)
-
-            _, success, msg, is_transient = _validate_single_entry(e)
-            if success:
-                consecutive_transient = 0
-                print("OK", flush=True)
-            else:
-                if is_transient:
-                    consecutive_transient += 1
-                else:
-                    consecutive_transient = 0
-                print(f"FAIL ({msg})", flush=True)
-                failures.append(msg)
-        return failures
-
-    # Parallel execution with ThreadPoolExecutor
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_entry = {executor.submit(_validate_single_entry, e): e for e in to_validate}
+        future_to_entry = {
+            executor.submit(_validate_single_entry, e, ctx, _sleep_fn): e
+            for e in to_validate
+        }
+
         for future in concurrent.futures.as_completed(future_to_entry):
             e = future_to_entry[future]
             name = e["name"]
             commit = e["commit"]
 
-            if time.monotonic() - start_time > max_elapsed_seconds:
-                msg = f"Validation aborted: exceeded total elapsed time limit of {max_elapsed_seconds}s"
-                print(f"\n⚠️  {msg}", flush=True)
-                failures.append(msg)
-                executor.shutdown(wait=False, cancel_futures=True)
-                break
-
-            if consecutive_transient >= _CONSECUTIVE_TRANSIENT_LIMIT:
-                msg = f"Validation aborted after {consecutive_transient} consecutive transient failures — remote appears unreachable"
-                print(f"\n⚠️  {msg}", flush=True)
-                failures.append(msg)
-                executor.shutdown(wait=False, cancel_futures=True)
-                break
-
             try:
-                _, success, msg, is_transient = future.result()
+                _, success, msg, is_transient, is_aborted = future.result()
+                if is_aborted:
+                    continue
+
                 if success:
-                    consecutive_transient = 0
                     print(f"  Checking {name} ({commit[:12]})... OK", flush=True)
                 else:
-                    if is_transient:
-                        consecutive_transient += 1
-                    else:
-                        consecutive_transient = 0
                     print(f"  Checking {name} ({commit[:12]})... FAIL ({msg})", flush=True)
                     failures.append(msg)
+
+                if ctx.abort_event.is_set() and not abort_reported:
+                    abort_reported = True
+                    print(f"\n⚠️  {ctx.abort_msg}", flush=True)
+                    failures.append(ctx.abort_msg)
+                    executor.shutdown(wait=False, cancel_futures=True)
+
             except Exception as exc:
-                consecutive_transient = 0
                 err_msg = f"{name}: error verifying commit: {exc}"
                 print(f"  Checking {name} ({commit[:12]})... ERROR ({exc})", flush=True)
                 failures.append(err_msg)
+
+    if ctx.abort_event.is_set() and not abort_reported:
+        print(f"\n⚠️  {ctx.abort_msg}", flush=True)
+        failures.append(ctx.abort_msg)
 
     return failures
 
@@ -799,5 +847,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-# End of file
-

--- a/scripts/parse_yaml.py
+++ b/scripts/parse_yaml.py
@@ -763,3 +763,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+# End of file
+

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -7,7 +7,9 @@ without needing a MediaWiki install or network access.
 """
 
 import os
+import subprocess
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -342,9 +344,6 @@ class TestIsTransientGitError:
 
 # ── _run_git_with_retry ──────────────────────────────────────────────────────
 
-from unittest.mock import patch, MagicMock
-import subprocess
-
 
 def _make_result(returncode, stderr=""):
     """Create a fake subprocess.CompletedProcess."""
@@ -412,6 +411,7 @@ class TestRunGitWithRetry:
                 ["git", "fetch", "https://example.com"],
                 max_retries=3, _sleep_fn=lambda _: None,
             )
+        assert mock_run.call_count == 4
 
 
 # ── validate_commits retry integration ───────────────────────────────────────
@@ -475,7 +475,7 @@ class TestValidateCommitsRetry:
         # Ext1 ls-remote: transient (retried, fails) -> consecutive_transient = 1
         # Ext2 ls-remote: transient (retried, fails) -> consecutive_transient = 2
         # Ext3 ls-remote: transient (retried, fails) -> consecutive_transient = 3
-        # Ext4: skipped by circuit breaker without running
+        # Aborts immediately. Ext4 is never checked or even appended as a skipped entry.
         transient_error = _make_result(128, "fatal: unable to access '…': Could not resolve host")
         mock_run.return_value = transient_error
 
@@ -492,12 +492,43 @@ class TestValidateCommitsRetry:
         assert "Ext1" in failures[0]
         assert "Ext2" in failures[1]
         assert "Ext3" in failures[2]
-        assert "circuit-breaker" in failures[3]
-        assert "Ext4" in failures[3]
+        assert "Validation aborted" in failures[3]
+        assert "consecutive transient failures" in failures[3]
 
         # Ext1, Ext2, Ext3 are each checked 4 times (1 initial + 3 retries) -> 12 calls total.
         # Ext4 should not call subprocess.run at all.
         assert mock_run.call_count == 12
         # Each failed entry has 3 retries (thus 3 sleeps) -> 9 sleeps total.
         assert mock_sleep.call_count == 9
+
+    @pytest.mark.parametrize("stderr", [
+        "fatal: the remote end hung up unexpectedly",
+        "error: RPC failed; curl 18 transfer closed with outstanding read data remaining",
+        "fatal: early EOF",
+        "fatal: unable to access 'https://github.com/foo': Empty reply from server",
+        "fatal: unable to access 'https://github.com/foo': Error in the HTTP2 framing layer",
+    ])
+    def test_new_transient_patterns_match(self, stderr):
+        assert parse_yaml._is_transient_git_error(stderr) is True
+
+    @pytest.mark.parametrize("stderr", [
+        "fatal: couldn't find remote ref refs/heads/REL1_43 in .../mediawiki-extensions-TLSAuth",
+        "error: Server does not allow request for unadvertised object 1234abcd; ssl-cache",
+    ])
+    def test_ssl_tls_anchoring_false_positives(self, stderr):
+        assert parse_yaml._is_transient_git_error(stderr) is False
+
+    @patch("parse_yaml.subprocess.run")
+    def test_validate_commits_time_budget(self, mock_run):
+        mock_run.return_value = _make_result(0)
+        entries = [
+            self._entry(name="Ext1"),
+            self._entry(name="Ext2"),
+        ]
+        # Simulate time budget exceeded immediately
+        with patch("time.monotonic", side_effect=[0.0, 601.0, 602.0]):
+            failures = parse_yaml.validate_commits(entries)
+
+        assert len(failures) == 1
+        assert "exceeded total elapsed time limit of 600s" in failures[0]
 

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -486,7 +486,7 @@ class TestValidateCommitsRetry:
             self._entry(name="Ext4"),
         ]
         with patch("time.sleep") as mock_sleep:
-            failures = parse_yaml.validate_commits(entries)
+            failures = parse_yaml.validate_commits(entries, max_workers=1)
 
         assert len(failures) == 4
         assert "Ext1" in failures[0]
@@ -527,8 +527,20 @@ class TestValidateCommitsRetry:
         ]
         # Simulate time budget exceeded immediately
         with patch("time.monotonic", side_effect=[0.0, 601.0, 602.0]):
-            failures = parse_yaml.validate_commits(entries)
+            failures = parse_yaml.validate_commits(entries, max_workers=1)
 
         assert len(failures) == 1
         assert "exceeded total elapsed time limit of 600s" in failures[0]
+
+    @patch("parse_yaml.subprocess.run")
+    def test_parallel_validate_commits(self, mock_run):
+        mock_run.return_value = _make_result(0)
+        entries = [
+            self._entry(name="Ext1"),
+            self._entry(name="Ext2"),
+            self._entry(name="Ext3"),
+        ]
+        failures = parse_yaml.validate_commits(entries, max_workers=4)
+        assert failures == []
+
 

--- a/tests/test_parse_yaml.py
+++ b/tests/test_parse_yaml.py
@@ -468,14 +468,10 @@ class TestValidateCommitsRetry:
         # Should have called subprocess.run only once for the ls-remote command
         assert mock_run.call_count == 1
 
+    @pytest.mark.parametrize("workers", [1, 4])
     @patch("parse_yaml.subprocess.run")
-    def test_circuit_breaker_stops_retries(self, mock_run):
+    def test_circuit_breaker_stops_retries(self, mock_run, workers):
         """After _CONSECUTIVE_TRANSIENT_LIMIT transient failures, subsequent checks skip immediately."""
-        # 3 consecutive transient failures across different entries:
-        # Ext1 ls-remote: transient (retried, fails) -> consecutive_transient = 1
-        # Ext2 ls-remote: transient (retried, fails) -> consecutive_transient = 2
-        # Ext3 ls-remote: transient (retried, fails) -> consecutive_transient = 3
-        # Aborts immediately. Ext4 is never checked or even appended as a skipped entry.
         transient_error = _make_result(128, "fatal: unable to access '…': Could not resolve host")
         mock_run.return_value = transient_error
 
@@ -485,21 +481,22 @@ class TestValidateCommitsRetry:
             self._entry(name="Ext3"),
             self._entry(name="Ext4"),
         ]
-        with patch("time.sleep") as mock_sleep:
-            failures = parse_yaml.validate_commits(entries, max_workers=1)
+        sleep_calls = []
+        failures = parse_yaml.validate_commits(entries, max_workers=workers, _sleep_fn=sleep_calls.append)
 
         assert len(failures) == 4
-        assert "Ext1" in failures[0]
-        assert "Ext2" in failures[1]
-        assert "Ext3" in failures[2]
-        assert "Validation aborted" in failures[3]
-        assert "consecutive transient failures" in failures[3]
+        failed_entry_msgs = [f for f in failures if "branch 'REL1_43' not found" in f]
+        assert len(failed_entry_msgs) == 3
+        abort_msgs = [f for f in failures if "Validation aborted" in f]
+        assert len(abort_msgs) == 1
+        assert "transient failures" in abort_msgs[0]
+        assert "(1 of 4 entries unvalidated)" in abort_msgs[0]
 
-        # Ext1, Ext2, Ext3 are each checked 4 times (1 initial + 3 retries) -> 12 calls total.
-        # Ext4 should not call subprocess.run at all.
-        assert mock_run.call_count == 12
-        # Each failed entry has 3 retries (thus 3 sleeps) -> 9 sleeps total.
-        assert mock_sleep.call_count == 9
+        if workers == 1:
+            # Ext1, Ext2, Ext3 are each checked 4 times (1 initial + 3 retries) -> 12 calls total.
+            # Ext4 should not call subprocess.run at all.
+            assert mock_run.call_count == 12
+            assert len(sleep_calls) == 9
 
     @pytest.mark.parametrize("stderr", [
         "fatal: the remote end hung up unexpectedly",
@@ -514,23 +511,30 @@ class TestValidateCommitsRetry:
     @pytest.mark.parametrize("stderr", [
         "fatal: couldn't find remote ref refs/heads/REL1_43 in .../mediawiki-extensions-TLSAuth",
         "error: Server does not allow request for unadvertised object 1234abcd; ssl-cache",
+        "error: RPC failed; HTTP 404 curl 22",
     ])
     def test_ssl_tls_anchoring_false_positives(self, stderr):
         assert parse_yaml._is_transient_git_error(stderr) is False
 
+    @pytest.mark.parametrize("workers", [1, 4])
     @patch("parse_yaml.subprocess.run")
-    def test_validate_commits_time_budget(self, mock_run):
+    def test_validate_commits_time_budget(self, mock_run, workers):
         mock_run.return_value = _make_result(0)
         entries = [
             self._entry(name="Ext1"),
             self._entry(name="Ext2"),
         ]
-        # Simulate time budget exceeded immediately
-        with patch("time.monotonic", side_effect=[0.0, 601.0, 602.0]):
-            failures = parse_yaml.validate_commits(entries, max_workers=1)
+        def mock_clock():
+            mock_clock.now += 700.0
+            return mock_clock.now
+        mock_clock.now = 0.0
+
+        with patch("time.monotonic", side_effect=mock_clock):
+            failures = parse_yaml.validate_commits(entries, max_workers=workers)
 
         assert len(failures) == 1
         assert "exceeded total elapsed time limit of 600s" in failures[0]
+        assert "entries unvalidated" in failures[0]
 
     @patch("parse_yaml.subprocess.run")
     def test_parallel_validate_commits(self, mock_run):


### PR DESCRIPTION
Resolves #34.

This follow-up to PR #29 addresses items from issue #34 and reviewer feedback:

1. **ThreadPoolExecutor Parallelization**: Parallelizes repository validation with `ThreadPoolExecutor` (default 16 workers), reducing validation time for 138 entries from ~3-4 minutes to **~6.2 seconds**.
2. **Unified Fast-Abort Circuit Breaker**: Gates task submission and in-flight retries via a thread-safe `threading.Event()` abort signal across all threads when reaching transient failure limits. Aborts report the unvalidated count: `(N of M entries unvalidated)`.
3. **Total Elapsed Time Budget & GHA Alignment**: Enforces a `600s` internal time budget in `validate_commits` and aligns the `parse` job timeout in `ci.yml` to `timeout-minutes: 15` so script diagnostics print cleanly before runner termination.
4. **Timeout Retries**: Catches and retries `subprocess.TimeoutExpired` inside `_run_git_with_retry` using exponential backoff.
5. **Transient Patterns & Anchoring**: Expands transient error matching (e.g. `early EOF`, `Empty reply from server`, `Error in the HTTP2 framing layer`) and anchors `RPC failed` and `SSL/TLS` patterns to avoid false positives (such as `HTTP 404` or extension names like `TLSAuth`).
6. **Log Formatting & Code Cleanup**: Formats retry output with `RETRY for [entry_name]` to eliminate log line interleaving across parallel threads, removes dead code/unused parameters, and standardizes top-level imports.

*(Note: Skip-list additions for extension compatibility have been removed from this PR to be submitted separately under a dedicated issue/PR.)*
