### PR TITLE
ci: add OATHAuth, SMW, SemanticDependencyUpdater, AntiSpoof, TimedMediaHandler to upstream_test_compat

### DIFF
--- a/.ci/skip_list.yaml
+++ b/.ci/skip_list.yaml
@@ -108,6 +108,16 @@ upstream_test_compat:
     reason: Integration test suite errors / dependency on SMW test classes
   - name: SemanticScribunto
     reason: Integration test suite errors / dependency on SMW test classes
+  - name: OATHAuth
+    reason: Requires christian-riesen/base32 library in isolated PHPUnit environment
+  - name: SemanticMediaWiki
+    reason: Requires onoi/cache library in isolated PHPUnit environment
+  - name: SemanticDependencyUpdater
+    reason: Dependency on SMW vendor libraries in isolated PHPUnit environment
+  - name: AntiSpoof
+    reason: Integration test suite errors under MediaWiki 1.43 / PHP 8.3
+  - name: TimedMediaHandler
+    reason: Integration test suite errors / FFmpeg dependencies under MediaWiki 1.43
 
 # ── Extensions with partial test exclusions ──────────────────────────────────
 # These extensions pass the vast majority of their test suite. Only a few


### PR DESCRIPTION
This PR adds 5 extensions (`OATHAuth`, `SemanticMediaWiki`, `SemanticDependencyUpdater`, `AntiSpoof`, `TimedMediaHandler`) to `upstream_test_compat` in `.ci/skip_list.yaml` as suggested in review for #37.

### Rationale & Categorization
- **OATHAuth**: Requires `christian-riesen/base32` library in isolated PHPUnit environment.
- **SemanticMediaWiki**: Requires `onoi/cache` library in isolated PHPUnit environment.
- **SemanticDependencyUpdater**: Dependency on SMW vendor libraries in isolated PHPUnit environment.
- **AntiSpoof**: Integration test suite errors under MediaWiki 1.43 / PHP 8.3.
- **TimedMediaHandler**: Integration test suite errors / FFmpeg dependencies under MediaWiki 1.43.


